### PR TITLE
Redesign maven plugin configuration

### DIFF
--- a/core/src/main/java/eu/softpol/lib/nullaudit/core/NullAuditAnalyzer.java
+++ b/core/src/main/java/eu/softpol/lib/nullaudit/core/NullAuditAnalyzer.java
@@ -1,6 +1,6 @@
 package eu.softpol.lib.nullaudit.core;
 
-import eu.softpol.lib.nullaudit.core.NullAuditConfig.CheckJSpecifyUsage;
+import eu.softpol.lib.nullaudit.core.NullAuditConfig.VerifyJSpecifyAnnotations;
 import eu.softpol.lib.nullaudit.core.NullAuditConfig.RequireSpecifiedNullness;
 import eu.softpol.lib.nullaudit.core.analyzer.ClassFileAnalyzer;
 import eu.softpol.lib.nullaudit.core.check.Check;
@@ -34,7 +34,7 @@ public class NullAuditAnalyzer {
   public NullAuditAnalyzer(Path input, List<String> excludedPackages) {
     this(input, new NullAuditConfig(
         excludedPackages,
-        new CheckJSpecifyUsage(null),
+        new VerifyJSpecifyAnnotations(null),
         null,
         new RequireSpecifiedNullness(null)
     ));
@@ -66,7 +66,7 @@ public class NullAuditAnalyzer {
   private static List<Check> toChecks(NullAuditConfig config) {
     var messageSolver = new MessageSolver();
     var result = new ArrayList<Check>();
-    Optional.ofNullable(config.checkJSpecifyUsage()).ifPresent(c -> {
+    Optional.ofNullable(config.verifyJSpecifyAnnotations()).ifPresent(c -> {
       List<Check> checks = List.of(
           new IrrelevantMarkedCheck(messageSolver),
           new IrrelevantPrimitiveCheck(messageSolver)

--- a/core/src/main/java/eu/softpol/lib/nullaudit/core/NullAuditConfig.java
+++ b/core/src/main/java/eu/softpol/lib/nullaudit/core/NullAuditConfig.java
@@ -5,12 +5,12 @@ import org.jspecify.annotations.Nullable;
 
 public record NullAuditConfig(
     List<String> excludedPackages,
-    @Nullable CheckJSpecifyUsage checkJSpecifyUsage,
+    @Nullable VerifyJSpecifyAnnotations verifyJSpecifyAnnotations,
     @Nullable RequireNullMarked requireNullMarked,
     @Nullable RequireSpecifiedNullness requireSpecifiedNullness
 ) {
 
-  public record CheckJSpecifyUsage(
+  public record VerifyJSpecifyAnnotations(
       @Nullable IgnoredClasses ignoredClasses
   ) {
 

--- a/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/BaseMojo.java
+++ b/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/BaseMojo.java
@@ -2,10 +2,23 @@ package eu.softpol.lib.nullaudit.maven;
 
 import static java.util.function.Predicate.not;
 
+import eu.softpol.lib.nullaudit.core.IgnoredClasses;
+import eu.softpol.lib.nullaudit.core.IgnoredClassesFileParser;
+import eu.softpol.lib.nullaudit.core.NullAuditConfig;
+import eu.softpol.lib.nullaudit.core.NullAuditConfig.VerifyJSpecifyAnnotations;
+import eu.softpol.lib.nullaudit.core.NullAuditConfig.RequireNullMarked;
+import eu.softpol.lib.nullaudit.core.NullAuditConfig.RequireSpecifiedNullness;
+import eu.softpol.lib.nullaudit.maven.config.BaseRule;
+import eu.softpol.lib.nullaudit.maven.config.VerifyJSpecifyAnnotationsRule;
+import eu.softpol.lib.nullaudit.maven.config.RequireSpecifiedNullnessRule;
+import eu.softpol.lib.nullaudit.maven.config.RulesConfig;
 import eu.softpol.lib.nullaudit.maven.i18n.MessageSolver;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.jspecify.annotations.Nullable;
@@ -21,6 +34,7 @@ public abstract class BaseMojo extends AbstractMojo {
    */
   @Parameter(property = "nullaudit.input", defaultValue = "${project.build.outputDirectory}")
   private @Nullable Path input;
+
   /**
    * Specifies a list of package names to exclude from the analysis. Package names can be separated
    * by commas, colons, or semicolons.
@@ -30,11 +44,29 @@ public abstract class BaseMojo extends AbstractMojo {
   @Parameter(property = "nullaudit.excludePackageNames")
   private @Nullable String excludePackageNames;
 
+  /**
+   * Specifies the rules configurations used for NullAudit checks. This variable holds specific rule
+   * settings that define different validation behaviors during the analysis process.
+   */
+  @Parameter
+  private RulesConfig rules;
+
   protected Path getInput() {
     return input;
   }
 
-  protected List<String> getExcludedPackages() {
+  protected RulesConfig getRulesOrDefault() {
+    if (rules != null) {
+      return rules;
+    }
+    return new RulesConfig(
+        null,
+        new RequireSpecifiedNullnessRule(),
+        new VerifyJSpecifyAnnotationsRule()
+    );
+  }
+
+  private List<String> getExcludedPackages() {
     if (excludePackageNames != null && !excludePackageNames.isEmpty()) {
       return Arrays.stream(excludePackageNames.split("[,:;]"))
           .map(String::trim)
@@ -43,5 +75,48 @@ public abstract class BaseMojo extends AbstractMojo {
     }
 
     return List.of();
+  }
+
+  protected NullAuditConfig createConfig() {
+    var rules = getRulesOrDefault();
+
+    return new NullAuditConfig(
+        getExcludedPackages(),
+        Optional.ofNullable(rules.getVerifyJSpecifyAnnotations())
+            .filter(BaseRule::isActive)
+            .map(r -> new VerifyJSpecifyAnnotations(
+                Optional.ofNullable(r.getIgnoredClassesFile())
+                    .map(BaseMojo::toIgnoredClasses)
+                    .orElse(null)
+            ))
+            .orElse(null),
+        Optional.ofNullable(rules.getRequireNullMarked())
+            .filter(BaseRule::isActive)
+            .map(r -> new RequireNullMarked(
+                Optional.ofNullable(r.getIgnoredClassesFile())
+                    .map(BaseMojo::toIgnoredClasses)
+                    .orElse(null)
+            ))
+            .orElse(null),
+        Optional.ofNullable(rules.getRequireSpecifiedNullness())
+            .filter(BaseRule::isActive)
+            .map(r -> new RequireSpecifiedNullness(
+                Optional.ofNullable(r.getIgnoredClassesFile())
+                    .map(BaseMojo::toIgnoredClasses)
+                    .orElse(null)
+            ))
+            .orElse(null)
+    );
+  }
+
+  private static @Nullable IgnoredClasses toIgnoredClasses(@Nullable String ignoredClassesFile) {
+    if (ignoredClassesFile == null || ignoredClassesFile.isBlank()) {
+      return null;
+    }
+    try {
+      return IgnoredClassesFileParser.parseIgnoredClassesFile(Path.of(ignoredClassesFile));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 }

--- a/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/CheckMojo.java
+++ b/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/CheckMojo.java
@@ -21,12 +21,12 @@ import org.apache.maven.plugins.annotations.Parameter;
 @Mojo(name = "check", requiresProject = false)
 public class CheckMojo extends BaseMojo {
 
-
   /**
    * Determines whether the build process should fail if null-audit analysis detects any problems.
    */
   @Parameter(property = "nullaudit.failOnError", defaultValue = "true")
   private boolean failOnError;
+
   /**
    * Limit the number of issues displayed on the console.
    */
@@ -34,7 +34,7 @@ public class CheckMojo extends BaseMojo {
   private int maxErrors;
 
   public void execute() throws MojoExecutionException {
-    var analyze = new NullAuditAnalyzer(getInput(), getExcludedPackages());
+    var analyze = new NullAuditAnalyzer(getInput(), createConfig());
     var report = analyze.run();
 
     var issuesCount = report.issues().size();

--- a/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/ReportMojo.java
+++ b/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/ReportMojo.java
@@ -35,7 +35,7 @@ public class ReportMojo extends BaseMojo {
   private String reportFile;
 
   public void execute() throws MojoExecutionException {
-    var analyze = new NullAuditAnalyzer(getInput(), getExcludedPackages());
+    var analyze = new NullAuditAnalyzer(getInput(), createConfig());
     var report = analyze.run();
 
     var reportPath = Path.of(reportFile).toAbsolutePath();

--- a/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/BaseRule.java
+++ b/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/BaseRule.java
@@ -1,0 +1,36 @@
+package eu.softpol.lib.nullaudit.maven.config;
+
+import org.apache.maven.plugins.annotations.Parameter;
+import org.jspecify.annotations.Nullable;
+
+public abstract class BaseRule {
+
+  /**
+   * Indicates whether the rule is active or not. Default value is true, meaning the rule is enabled
+   * by default.
+   */
+  @Parameter(defaultValue = "true")
+  private boolean active = true;
+
+  /**
+   * A file listing classes (or patterns) to ignore for this rule.
+   */
+  @Parameter
+  private @Nullable String ignoredClassesFile;
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
+  public @Nullable String getIgnoredClassesFile() {
+    return ignoredClassesFile;
+  }
+
+  public void setIgnoredClassesFile(String ignoredClassesFile) {
+    this.ignoredClassesFile = ignoredClassesFile;
+  }
+}

--- a/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/RequireNullMarkedRule.java
+++ b/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/RequireNullMarkedRule.java
@@ -1,0 +1,8 @@
+package eu.softpol.lib.nullaudit.maven.config;
+
+/**
+ * Configuration for the <requireNullMarked> rule.
+ */
+public class RequireNullMarkedRule extends BaseRule {
+
+}

--- a/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/RequireSpecifiedNullnessRule.java
+++ b/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/RequireSpecifiedNullnessRule.java
@@ -1,0 +1,8 @@
+package eu.softpol.lib.nullaudit.maven.config;
+
+/**
+ * Configuration for the <requireSpecifiedNullness> rule.
+ */
+public class RequireSpecifiedNullnessRule extends BaseRule {
+
+}

--- a/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/RulesConfig.java
+++ b/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/RulesConfig.java
@@ -1,0 +1,67 @@
+package eu.softpol.lib.nullaudit.maven.config;
+
+import org.apache.maven.plugins.annotations.Parameter;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents the <rules> block in the configuration. It holds each specific rule as an object
+ * field.
+ */
+public class RulesConfig {
+
+  /**
+   * This rule ensures that the codebase uses the @NullMarked annotation to explicitly indicate
+   * nullability scope.
+   */
+  @Parameter
+  private @Nullable RequireNullMarkedRule requireNullMarked;
+
+  /**
+   * This rule enforces that the code explicitly specify nullability.
+   */
+  @Parameter
+  private @Nullable RequireSpecifiedNullnessRule requireSpecifiedNullness;
+
+  /**
+   * This rule is used to validate the proper usage of the JSpecify annotations.
+   */
+  @Parameter
+  private @Nullable VerifyJSpecifyAnnotationsRule verifyJSpecifyAnnotations;
+
+  public RulesConfig() {
+  }
+
+  public RulesConfig(
+      @Nullable RequireNullMarkedRule requireNullMarked,
+      @Nullable RequireSpecifiedNullnessRule requireSpecifiedNullness,
+      @Nullable VerifyJSpecifyAnnotationsRule verifyJSpecifyAnnotations
+  ) {
+    this.requireNullMarked = requireNullMarked;
+    this.requireSpecifiedNullness = requireSpecifiedNullness;
+    this.verifyJSpecifyAnnotations = verifyJSpecifyAnnotations;
+  }
+
+  public @Nullable RequireNullMarkedRule getRequireNullMarked() {
+    return requireNullMarked;
+  }
+
+  public void setRequireNullMarked(@Nullable RequireNullMarkedRule requireNullMarked) {
+    this.requireNullMarked = requireNullMarked;
+  }
+
+  public @Nullable RequireSpecifiedNullnessRule getRequireSpecifiedNullness() {
+    return requireSpecifiedNullness;
+  }
+
+  public void setRequireSpecifiedNullness(@Nullable RequireSpecifiedNullnessRule requireSpecifiedNullness) {
+    this.requireSpecifiedNullness = requireSpecifiedNullness;
+  }
+
+  public @Nullable VerifyJSpecifyAnnotationsRule getVerifyJSpecifyAnnotations() {
+    return verifyJSpecifyAnnotations;
+  }
+
+  public void setVerifyJSpecifyAnnotations(@Nullable VerifyJSpecifyAnnotationsRule verifyJSpecifyAnnotations) {
+    this.verifyJSpecifyAnnotations = verifyJSpecifyAnnotations;
+  }
+}

--- a/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/VerifyJSpecifyAnnotationsRule.java
+++ b/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/VerifyJSpecifyAnnotationsRule.java
@@ -1,0 +1,8 @@
+package eu.softpol.lib.nullaudit.maven.config;
+
+/**
+ * Configuration for the <verifyJSpecifyAnnotations> rule.
+ */
+public class VerifyJSpecifyAnnotationsRule extends BaseRule {
+
+}


### PR DESCRIPTION
Added ability to configure rules for Maven plugin

```xml
 <configuration>
  <rules>
    <requireNullMarked>
      <active>true</active>
      <ignoredClassesFile>legacy-classes.txt</ignoredClassesFile>
    </requireNullMarked>
    <requireSpecifiedNullness>
      <active>true</active>
      <ignoredClassesFile>legacy-classes.txt</ignoredClassesFile>
    </requireSpecifiedNullness>
    <verifyJSpecifyAnnotations>
      <active>true</active>
    </verifyJSpecifyAnnotations>
  </rules>
</configuration>
```

`<ignoredClassesFile>` points to a text file with the listed classes to be ignored