### PR TITLE
<excludeAnnotations> added

### DIFF
--- a/core/src/main/java/eu/softpol/lib/nullaudit/core/Exclusions.java
+++ b/core/src/main/java/eu/softpol/lib/nullaudit/core/Exclusions.java
@@ -3,24 +3,25 @@ package eu.softpol.lib.nullaudit.core;
 import java.util.Set;
 
 public record Exclusions(
-    Set<String> classes
+    Set<String> classes,
+    Set<String> annotations
 ) {
 
-  private static final Exclusions EMPTY = new Exclusions(Set.of());
+  private static final Exclusions EMPTY = new Exclusions(Set.of(), Set.of());
 
   public boolean isEmpty() {
-    return classes.isEmpty();
+    return classes.isEmpty() && annotations.isEmpty();
   }
 
   public static Exclusions empty() {
     return EMPTY;
   }
 
-  public static Exclusions of(Set<String> classes) {
-    return new Exclusions(Set.copyOf(classes));
+  public static Exclusions ofClasses(Set<String> classes) {
+    return new Exclusions(Set.copyOf(classes), Set.of());
   }
 
-  public static Exclusions of(String... classes) {
-    return new Exclusions(Set.of(classes));
+  public static Exclusions ofClasses(String... classes) {
+    return new Exclusions(Set.of(classes), Set.of());
   }
 }

--- a/core/src/main/java/eu/softpol/lib/nullaudit/core/ExclusionsFileParser.java
+++ b/core/src/main/java/eu/softpol/lib/nullaudit/core/ExclusionsFileParser.java
@@ -19,7 +19,7 @@ public class ExclusionsFileParser {
    * @return exclusions object
    * @throws IOException in case of IO problems.
    */
-  public static Exclusions parse(Path filePath) throws IOException {
+  public static Set<String> parse(Path filePath) throws IOException {
     Set<String> patterns = new HashSet<>();
 
     for (String line : Files.readAllLines(filePath, StandardCharsets.UTF_8)) {
@@ -31,7 +31,7 @@ public class ExclusionsFileParser {
       patterns.add(trimmed);
     }
 
-    return new Exclusions(Set.copyOf(patterns));
+    return Set.copyOf(patterns);
   }
 
 

--- a/core/src/test/java/eu/softpol/lib/nullaudit/coretest/rules/require_nullmarked/RequireNullMarkedExcludeTest.java
+++ b/core/src/test/java/eu/softpol/lib/nullaudit/coretest/rules/require_nullmarked/RequireNullMarkedExcludeTest.java
@@ -48,7 +48,7 @@ class RequireNullMarkedExcludeTest {
   @Test
   void shouldNotReportExcludedClasses() {
     var config = NullAuditConfig.of()
-        .withRequireNullMarked(new RequireNullMarked(Exclusions.of(
+        .withRequireNullMarked(new RequireNullMarked(Exclusions.ofClasses(
             "demo.Prefix1",
             "demo.Prefix2",
             "demo.foo.Prefix4"
@@ -61,7 +61,7 @@ class RequireNullMarkedExcludeTest {
   @Test
   void shouldNotReportExcludedWildcardClasses() {
     var config = NullAuditConfig.of()
-        .withRequireNullMarked(new RequireNullMarked(Exclusions.of(
+        .withRequireNullMarked(new RequireNullMarked(Exclusions.ofClasses(
             "demo.*"
         ), On.CLASS));
     var analyzer = new NullAuditAnalyzer(dir, config);
@@ -76,7 +76,7 @@ class RequireNullMarkedExcludeTest {
   @Test
   void shouldNotReportExcludedWildcardClassesAndSubpackages() {
     var config = NullAuditConfig.of()
-        .withRequireNullMarked(new RequireNullMarked(Exclusions.of(
+        .withRequireNullMarked(new RequireNullMarked(Exclusions.ofClasses(
             "demo.**"
         ), On.CLASS));
     var analyzer = new NullAuditAnalyzer(dir, config);

--- a/core/src/test/java/eu/softpol/lib/nullaudit/coretest/rules/require_specified_nullness/RequireSpecifiedNullnessExcludeTest.java
+++ b/core/src/test/java/eu/softpol/lib/nullaudit/coretest/rules/require_specified_nullness/RequireSpecifiedNullnessExcludeTest.java
@@ -11,7 +11,6 @@ import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.compilers.JctCompilers;
 import io.github.ascopes.jct.workspaces.Workspaces;
 import java.nio.file.Path;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -49,11 +48,11 @@ class RequireSpecifiedNullnessExcludeTest {
   @Test
   void shouldNotReportExcludedClasses() {
     var config = NullAuditConfig.of()
-        .withRequireSpecifiedNullness(new RequireSpecifiedNullness(new Exclusions(Set.of(
+        .withRequireSpecifiedNullness(new RequireSpecifiedNullness(Exclusions.ofClasses(
             "demo.Prefix1",
             "demo.Prefix2",
             "demo.foo.Prefix4"
-        ))));
+        )));
     var analyzer = new NullAuditAnalyzer(dir, config);
     var report = analyzer.run();
     assertThat(report)
@@ -71,9 +70,9 @@ class RequireSpecifiedNullnessExcludeTest {
   @Test
   void shouldNotReportExcludedWildcardClasses() {
     var config = NullAuditConfig.of()
-        .withRequireSpecifiedNullness(new RequireSpecifiedNullness(new Exclusions(Set.of(
+        .withRequireSpecifiedNullness(new RequireSpecifiedNullness(Exclusions.ofClasses(
             "demo.*"
-        ))));
+        )));
     var analyzer = new NullAuditAnalyzer(dir, config);
     var report = analyzer.run();
     assertThat(report)
@@ -91,9 +90,9 @@ class RequireSpecifiedNullnessExcludeTest {
   @Test
   void shouldNotReportExcludedWildcardClassesAndSubpackages() {
     var config = NullAuditConfig.of()
-        .withRequireSpecifiedNullness(new RequireSpecifiedNullness(new Exclusions(Set.of(
+        .withRequireSpecifiedNullness(new RequireSpecifiedNullness(Exclusions.ofClasses(
             "demo.**"
-        ))));
+        )));
     var analyzer = new NullAuditAnalyzer(dir, config);
     var report = analyzer.run();
     assertThat(report.issues()).isEmpty();

--- a/core/src/test/java/eu/softpol/lib/nullaudit/coretest/rules/verify_jspecify_annotations/VerifyJSpecifyAnnotationsExcludeTest.java
+++ b/core/src/test/java/eu/softpol/lib/nullaudit/coretest/rules/verify_jspecify_annotations/VerifyJSpecifyAnnotationsExcludeTest.java
@@ -11,7 +11,6 @@ import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.compilers.JctCompilers;
 import io.github.ascopes.jct.workspaces.Workspaces;
 import java.nio.file.Path;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,11 +47,11 @@ class VerifyJSpecifyAnnotationsExcludeTest {
   @Test
   void shouldNotReportExcludedClasses() {
     var config = NullAuditConfig.of()
-        .withVerifyJSpecifyAnnotations(new VerifyJSpecifyAnnotations(new Exclusions(Set.of(
+        .withVerifyJSpecifyAnnotations(new VerifyJSpecifyAnnotations(Exclusions.ofClasses(
             "demo.Prefix1",
             "demo.Prefix2",
             "demo.foo.Prefix4"
-        ))));
+        )));
     var analyzer = new NullAuditAnalyzer(dir, config);
     var report = analyzer.run();
     assertThat(report)
@@ -70,9 +69,9 @@ class VerifyJSpecifyAnnotationsExcludeTest {
   @Test
   void shouldNotReportExcludedWildcardClasses() {
     var config = NullAuditConfig.of()
-        .withVerifyJSpecifyAnnotations(new VerifyJSpecifyAnnotations(new Exclusions(Set.of(
+        .withVerifyJSpecifyAnnotations(new VerifyJSpecifyAnnotations(Exclusions.ofClasses(
             "demo.*"
-        ))));
+        )));
     var analyzer = new NullAuditAnalyzer(dir, config);
     var report = analyzer.run();
     assertThat(report)
@@ -90,9 +89,9 @@ class VerifyJSpecifyAnnotationsExcludeTest {
   @Test
   void shouldNotReportExcludedWildcardClassesAndSubpackages() {
     var config = NullAuditConfig.of()
-        .withVerifyJSpecifyAnnotations(new VerifyJSpecifyAnnotations(new Exclusions(Set.of(
+        .withVerifyJSpecifyAnnotations(new VerifyJSpecifyAnnotations(Exclusions.ofClasses(
             "demo.**"
-        ))));
+        )));
     var analyzer = new NullAuditAnalyzer(dir, config);
     var report = analyzer.run();
     assertThat(report.issues()).isEmpty();

--- a/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/BaseRule.java
+++ b/maven-plugin/src/main/java/eu/softpol/lib/nullaudit/maven/config/BaseRule.java
@@ -15,6 +15,19 @@ public abstract class BaseRule {
   private boolean active = true;
 
   /**
+   * Comma-separated list of fully-qualified annotation names that cause the rule to skip the
+   * annotated element and, optionally, its members.
+   *
+   * <p>
+   * Typical use-case: exclude generated code by listing annotations such as
+   * {@code javax.annotation.Generated} or {@code jakarta.annotation.Generated}.
+   *
+   * <p>If {@code null} or empty, no annotation-based exclusions are applied.</p>
+   */
+  @Parameter
+  private @Nullable String excludeAnnotations;
+
+  /**
    * A file listing classes (or patterns) to ignore for this rule.
    */
   @Parameter
@@ -26,6 +39,14 @@ public abstract class BaseRule {
 
   public void setActive(boolean active) {
     this.active = active;
+  }
+
+  public @Nullable String getExcludeAnnotations() {
+    return excludeAnnotations;
+  }
+
+  public void setExcludeAnnotations(@Nullable String excludeAnnotations) {
+    this.excludeAnnotations = excludeAnnotations;
   }
 
   public @Nullable String getExclusionsFile() {


### PR DESCRIPTION
Related https://github.com/mk868/nullaudit/issues/50

Adds <excludeAnnotations> so that rules can skip classes/members annotated with e.g. `@Entity`.

* New config option `excludeAnnotations` (comma-separated, Ant-style wildcards supported).
* Applies to `requireSpecifiedNullness`, `verifyJSpecifyAnnotations`, `requireNullMarked`.

For sample configuration
```xml
<configuration>
  <rules>
    <requireSpecifiedNullness>
      <excludeAnnotations>jakarta.persistence.Entity</excludeAnnotations>
    </requireSpecifiedNullness>
  </rules>
</configuration>
```

The following class will be ignored in analysis:
```java
import jakarta.persistence.Column;
import jakarta.persistence.Entity;
import jakarta.persistence.Id;

@Entity
public class UserEntity { // will be skipped

  @Id
  private String id;
  @Column(nullable = false)
  private String name;
  @Column(nullable = false)
  private String surname;

}
```